### PR TITLE
Fix missing profiling dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,6 @@ Werkzeug==2.3.7
 matplotlib==3.7.2
 numpy==1.24.3
 scipy==1.11.1
+pandas==2.2.2
+ydata-profiling==4.6.4
 


### PR DESCRIPTION
## Summary
- ensure pandas and ydata-profiling are installed by default

## Testing
- `pip install -r requirements.txt` *(fails: Cannot import 'setuptools.build_meta')*

------
https://chatgpt.com/codex/tasks/task_e_6882845532b4832eb757b5b3b215e3af