### PR TITLE
Fix missing profiling window

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,6 @@ Werkzeug==2.3.7
 matplotlib==3.7.2
 numpy==1.24.3
 scipy==1.11.1
+pandas==2.2.2
+ydata-profiling==4.6.4
 

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -1376,13 +1376,23 @@
         function showModal(title, content) {
             const modal = document.getElementById('plotModal');
             const modalContent = document.getElementById('modalContent');
-            
+
             modalContent.innerHTML = `
                 <h2 style="color: #1e293b; margin-bottom: 20px;">${title}</h2>
                 ${content}
             `;
-            
+
             modal.style.display = 'block';
+        }
+
+        function openProfiling() {
+            if (window.profilingReportHTML) {
+                const w = window.open('about:blank');
+                w.document.write(window.profilingReportHTML);
+                w.document.close();
+            } else {
+                alert('Relatório de profiling não disponível.');
+            }
         }
 
         function createDescribeTable(data) {


### PR DESCRIPTION
## Summary
- added openProfiling function to show pandas-profiling report
- ensure pandas and ydata-profiling are included in requirements

## Testing
- `pip install -r requirements.txt` *(fails: Cannot import 'setuptools.build_meta')*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882845532b4832eb757b5b3b215e3af