### PR TITLE
Fix profiling button

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,6 @@ Werkzeug==2.3.7
 matplotlib==3.7.2
 numpy==1.24.3
 scipy==1.11.1
+pandas==2.2.2
+ydata-profiling==4.6.4
 

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -714,6 +714,7 @@
         let currentFile = null;
         let targetColumn = null;
         let datasetInfo = null;
+        let profilingWindow = null;
 
         // Inicialização
         document.addEventListener('DOMContentLoaded', function() {
@@ -1263,6 +1264,10 @@
         async function generateProfiling() {
             if (!targetColumn) return;
 
+            if (!profilingWindow || profilingWindow.closed) {
+                profilingWindow = window.open('about:blank');
+            }
+
             try {
                 const response = await fetch('/api/statistics', {
                     method: 'POST',
@@ -1281,9 +1286,15 @@
                     openProfiling();
                 } else {
                     alert('Perfilamento indisponível.');
+                    if (profilingWindow) {
+                        profilingWindow.close();
+                    }
                 }
             } catch (error) {
                 alert('Erro ao gerar perfilamento: ' + error.message);
+                if (profilingWindow) {
+                    profilingWindow.close();
+                }
             }
         }
 
@@ -1376,14 +1387,33 @@
         function showModal(title, content) {
             const modal = document.getElementById('plotModal');
             const modalContent = document.getElementById('modalContent');
-            
+
             modalContent.innerHTML = `
                 <h2 style="color: #1e293b; margin-bottom: 20px;">${title}</h2>
                 ${content}
             `;
-            
+
             modal.style.display = 'block';
         }
+
+        function openProfiling() {
+            if (!window.profilingReportHTML) {
+                alert('Relatório de profiling não disponível.');
+                return;
+            }
+
+            if (!profilingWindow || profilingWindow.closed) {
+                profilingWindow = window.open('about:blank');
+            }
+
+            if (profilingWindow) {
+                profilingWindow.document.write(window.profilingReportHTML);
+                profilingWindow.document.close();
+            } else {
+                alert('Não foi possível abrir a janela de profiling. Verifique o bloqueador de pop-ups.');
+            }
+        }
+        window.openProfiling = openProfiling;
 
         function createDescribeTable(data) {
             const columns = Object.keys(data || {});


### PR DESCRIPTION
## Summary
- expose the profiling window globally so it can be opened more reliably
- open a blank popup before the profiling request to avoid blocked pop‑ups

## Testing
- `pip install -r requirements.txt` *(fails: Cannot import 'setuptools.build_meta')*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882845532b4832eb757b5b3b215e3af